### PR TITLE
More compact annotations

### DIFF
--- a/company-anaconda.el
+++ b/company-anaconda.el
@@ -64,7 +64,7 @@ Apply passed CALLBACK to extracted collection."
 (defun company-anaconda-annotation (candidate)
   "Return annotation string for chosen CANDIDATE."
   (--when-let (get-text-property 0 'description candidate)
-    (concat "<" it ">")))
+    (concat "<" (s-left 1 it) ">")))
 
 (defun company-anaconda-location (candidate)
   "Return location (path . line) for chosen CANDIDATE."


### PR DESCRIPTION
Hi!  Thanks for anaconda-mode and company-anaconda.  They are essential for me.

I just grabbed the latest versions of both from GitHub, and noticed that my completions were now looking like 

```
baz_eek <method: FooBar.baz_eek>
```

I gather the `<...>` bits are the "annotation."  I feel like these annotations are often a bit too long.  (The above example was not the longest annotation I ran into, not by far!)

I looked at how some other modes do this, and I saw that [Cider, for example, just displays the type of the object][cider-annotations], like just `<m>` for methods.  This seemed good to me, so I'm proposing this as a change for company-anaconda.

I could also add in some kind of customization variable to enable or disable this behavior, if you prefer.

[cider-annotations]: https://github.com/clojure-emacs/cider#completion-annotations