### PR TITLE
Allow customization of annotation formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,45 @@ Enable ``anaconda-mode`` in buffers you want to use ``company-anaconda``
 
     (add-hook 'python-mode-hook 'anaconda-mode)
 
+Customization
+-------------
+
+By default, company-anaconda uses Jedi's ``description`` for
+candidates as annotations in company-mode's list of completions.  This
+usually tells you the type, and often the fully-qualified name, of a
+completion candidate.  For example, for a candidate ``a_method``, you
+may see the annotation ``<function: some_module.SomeClass.a_method>``.
+
+You can customize these annotations by setting
+``company-anaconda-annotation-function`` to a function that takes a
+candidate string and returns the string company-mode should use as the
+annotation for that candidate.  The candidate string *may* have the
+following text properties, which provide additional information about the candidate:
+
+- description: Jedi's description, typically the type of completion
+  optionally followed by a fully-qualified name for the candidate.  For example, \"class: foo.bar.Baz\" or \"statement\".
+
+- module-path: The path to the file that contains this candidate.
+
+- line: The line within that file where the candidate is defined.
+
+- docstring: The candidate's docstring.
+
+Here is an example of an alternate annotation function that only returns the first letter of the candidate's ``description`` property (indicating its type) in chevrons:
+
+.. code:: lisp
+
+    (defun my-annotation-function (candidate)
+      (let ((description (get-text-property 0 'description candidate)))
+        (when description
+          (concat "<" (substring description 0 1) ">"))))
+
+    (setq company-anaconda-annotation-function 'my-annotation-function)
+
+For a candidate with a description such as ``function:
+some_module.SomeClass.a_method``, this would make its annotation in
+company-mode's completion list simply ``<f>``.
+
 .. _Anaconda: https://github.com/proofit404/anaconda-mode
 .. _company-mode: http://company-mode.github.io/
 .. _Melpa: http://melpa.milkbox.net/


### PR DESCRIPTION
Per your suggestion in #10, users can set `company-anaconda-format-annotation-function` to a function that will take Jedi's description and return the annotation string to be used for this candidate by company-mode.

I'm happy to make further edits to this PR at your request!  Thanks for your consideration.