### PR TITLE
Remove newlines from annotation

### DIFF
--- a/company-anaconda.el
+++ b/company-anaconda.el
@@ -74,7 +74,7 @@ This will return a string such as,
 \"<function: mod.Klass.a_function>\".  This is primarily for use
 as a possible value for `company-anaconda-annotation-function'."
   (--when-let (get-text-property 0 'description candidate)
-    (concat "<" it ">")))
+    (concat "<" (s-replace "\n" "" it) ">")))
 
 (defcustom company-anaconda-case-insensitive t
   "Use case insensitive candidates match."


### PR DESCRIPTION
Sometimes the return value of `company-anaconda-description-in-chevrons` contains a newline and it causes an error (see [this issue](https://github.com/company-mode/company-mode/issues/520)). Merging this fix the problem.