### PR TITLE
(#28) Don't count end of number constants for completion besides float

### DIFF
--- a/company-anaconda.el
+++ b/company-anaconda.el
@@ -48,12 +48,25 @@
   :group 'company-anaconda
   :type 'boolean)
 
+(defun company-anaconda-at-the-end-of-identifier ()
+  "Check if the cursor at the end of completable identifier."
+  (or
+   ;; At the end of the symbol, but not the end of int number
+   (and (looking-at "\\_>")
+	(not (looking-back "\\_<[[:digit:]]+" (line-beginning-position))))
+   ;; After the dot, but not when it's a dot after int number
+   ;; Although identifiers like "foo1.", "foo111.", or "foo1baz2." are ok
+   (and (looking-back "\\." (- (point) 1))
+	(not (looking-back "\\_<[[:digit:]]+\\." (line-beginning-position))))
+   ;; After dot in float constant like "1.1." or ".1."
+   (or (looking-back "\\_<[[:digit:]]+\\.[[:digit:]]+\\." (line-beginning-position))
+       (looking-back "\\.[[:digit:]]+\\." (line-beginning-position)))))
+
 (defun company-anaconda-prefix ()
   "Grab prefix at point."
   (and anaconda-mode
        (not (company-in-string-or-comment))
-       (or (looking-at "\\_>")
-           (looking-back "\\." (- (point) 1)))
+       (company-anaconda-at-the-end-of-identifier)
        (let* ((line-start (line-beginning-position))
               (start
                (save-excursion


### PR DESCRIPTION
Here's a solution for the end of number completion suggestion resolution.
My elisp skills are so-so at best, so probably here's a room for improvement.
I've also checked if it affects current performance, and for me it doesn't, both in candidates appearance delay and in consumed CPU resources.

There are still uncovered rare corner cases. For example, `1.1.1.1.|` and `a11.1.|` will show float methods, but I don't think we should do something about it (at least now). PyCharm doesn't handle them as well and everybody is happy :)

What do you think?