### PR TITLE
Don't complete when typing integers in all forms

### DIFF
--- a/company-anaconda.el
+++ b/company-anaconda.el
@@ -53,11 +53,12 @@
   (or
    ;; At the end of the symbol, but not the end of int number
    (and (looking-at "\\_>")
-	(not (looking-back "\\_<[[:digit:]]+" (line-beginning-position))))
+        (not (looking-back "\\_<\\(0[bo]\\)?[[:digit:]]+" (line-beginning-position)))
+        (not (looking-back "\\_<0x[[:xdigit:]]+" (line-beginning-position))))
    ;; After the dot, but not when it's a dot after int number
    ;; Although identifiers like "foo1.", "foo111.", or "foo1baz2." are ok
    (and (looking-back "\\." (- (point) 1))
-	(not (looking-back "\\_<[[:digit:]]+\\." (line-beginning-position))))
+        (not (looking-back "\\_<[[:digit:]]+\\." (line-beginning-position))))
    ;; After dot in float constant like "1.1." or ".1."
    (or (looking-back "\\_<[[:digit:]]+\\.[[:digit:]]+\\." (line-beginning-position))
        (looking-back "\\.[[:digit:]]+\\." (line-beginning-position)))))


### PR DESCRIPTION
What #30 has done only works for integers with `DEC` form. This pull request extends it to all the forms integers could have.
According to PEP 3127, integers can also be represented in `BIN`,`OCT` or `HEX` forms, such as `0b10`, `0o12` or `0xab`.
Other forms could have its own functions, such as `0xab.bit_length()` is allowed. So we don't need to change the second case.
